### PR TITLE
Avoid using 'origin' and prefer 'fork'

### DIFF
--- a/bin/git-branch-delete
+++ b/bin/git-branch-delete
@@ -1,34 +1,36 @@
 #!/bin/sh
 
+. remote-aliases
+
 function _delete_force {
   if [ -d .git ]; then
-    echo "Deleting branch '$(git-current-branch)' on origin"
-    git push --delete origin `git-current-branch`
+    echo "Deleting branch '$(git-current-branch)' on $FORK_ALIAS"
+    git push --delete $FORK_ALIAS `git-current-branch`
 
     # delete that folder
     DIR_TO_DELETE=`pwd`
 
     echo "Deleting dir '$DIR_TO_DELETE'"
     rm -rf $DIR_TO_DELETE
-  else 
+  else
     echo "Not a git repository"
-  fi 
+  fi
 }
 
 if [ -d "$1" ]; then
     cd $1
     if [ -f .prinfo ]; then
-        PR_STATE=`git-is-merged` 
-        
+        PR_STATE=`git-is-merged`
+
         if [ "$PR_STATE" = "true" ]; then
             _delete_force $1
-        else 
+        else
             source .prinfo
             echo "This branch $i has an open and unmerged PR"
             echo "Check it at $PR_URL"
             echo "To force deletion, first remove $1/.prinfo filecall"
-        fi 
+        fi
     else
         _delete_force $1
-    fi     
-fi 
+    fi
+fi

--- a/bin/git-clone-fork
+++ b/bin/git-clone-fork
@@ -1,20 +1,22 @@
 #!/bin/sh
 
-  REPO=$1
-  PROJ=${REPO#*/}
-  DIR=${PROJ%*.git}
-  git clone $REPO
+. remote-aliases
 
-  echo "Moving into $DIR"
-  cd $DIR
-  CURRENT_BRANCH=`git-current-branch`
-  cd ../
+REPO=$1
+PROJ=${REPO#*/}
+DIR=${PROJ%*.git}
+git clone $REPO
 
-  echo "Preparing branch: '$CURRENT_BRANCH'"
-  git-prepare $DIR $CURRENT_BRANCH
+echo "Moving into $DIR"
+cd $DIR
+CURRENT_BRANCH=`git-current-branch`
+cd ../
 
-  echo "Moving to $DIR/$CURRENT_BRANCH"
-  cd $DIR/$CURRENT_BRANCH
+echo "Preparing branch: '$CURRENT_BRANCH'"
+git-prepare $DIR $CURRENT_BRANCH
 
-  echo "Forking..."
-  git fork --remote-name=$FORK_ALIAS
+echo "Moving to $DIR/$CURRENT_BRANCH"
+cd $DIR/$CURRENT_BRANCH
+
+echo "Forking..."
+git fork --remote-name=$FORK_ALIAS

--- a/bin/git-clone-fork
+++ b/bin/git-clone-fork
@@ -4,7 +4,7 @@
   PROJ=${REPO#*/}
   DIR=${PROJ%*.git}
   git clone $REPO
-  
+
   echo "Moving into $DIR"
   cd $DIR
   CURRENT_BRANCH=`git-current-branch`
@@ -17,4 +17,4 @@
   cd $DIR/$CURRENT_BRANCH
 
   echo "Forking..."
-  git fork --remote-name=origin
+  git fork --remote-name=$FORK_ALIAS

--- a/bin/git-pr-create
+++ b/bin/git-pr-create
@@ -4,11 +4,11 @@ if [ -f .prinfo ]; then
   rm .prinfo
 fi
 
-git-push-origin
+git-push-fork
 PR_URL=$(hub pull-request $@)
 
 PATH_URL=`echo ${PR_URL#*https://github.com/} | sed  's/\/pull\//\/pulls\//g'`
-PR_API_URL="https://api.github.com/repos/$PATH_URL" 
+PR_API_URL="https://api.github.com/repos/$PATH_URL"
 
 echo "PR URL: $PR_URL"
 echo "PR API URL: $PR_API_URL"

--- a/bin/git-pr-create
+++ b/bin/git-pr-create
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. remote-aliases
+
 if [ -f .prinfo ]; then
   rm .prinfo
 fi

--- a/bin/git-push-fork
+++ b/bin/git-push-fork
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git push --set-upstream $FORK_ALIAS `git-current-branch`

--- a/bin/git-push-fork
+++ b/bin/git-push-fork
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+. remote-aliases
+
 git push --set-upstream $FORK_ALIAS `git-current-branch`

--- a/bin/git-push-origin
+++ b/bin/git-push-origin
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-git push --set-upstream origin `git-current-branch`

--- a/bin/git-wbranch
+++ b/bin/git-wbranch
@@ -1,30 +1,30 @@
 #!/bin/sh
 
 # create a working branch, similar to `git worktree`
-# but works by creating a local clone 
+# but works by creating a local clone
 
 if [ -d .git ]; then
   git-pull-upstream
-    
+
   REPO=${PWD##*/}
 
   # save remote urls for later
   UPSTREAM_REMOTE_URL=`git remote get-url upstream`
-  ORIGIN_REMOTE_URL=`git remote get-url origin`
+  FORK_REMOTE_URL=`git remote get-url $FORK_ALIAS`
 
   cd ../
   git clone ${REPO} $1
   cd $1
 
-  # local points to origin (original local checkout)
-  git remote add local `git remote get-url origin`
+  # local points to $FORK_ALIAS (original local checkout)
+  git remote add local `git remote get-url $FORK_ALIAS`
 
-  # remove origin and read point to remove
-  git remote remove origin
-  git remote add origin $ORIGIN_REMOTE_URL
+  # remove current $FORK_ALIAS and read point to remote
+  git remote remove $FORK_ALIAS
+  git remote add $FORK_ALIAS $FORK_REMOTE_URL
 
   # add upstream pointing to remote
-  git remote add upstream $UPSTREAM_REMOTE_URL
+  git remote add upstream $FORK_REMOTE_URL
 
   # check it out using new branch
   git checkout -b $1

--- a/bin/git-wbranch
+++ b/bin/git-wbranch
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. remote-aliases
+
 # create a working branch, similar to `git worktree`
 # but works by creating a local clone
 

--- a/bin/remote-aliases
+++ b/bin/remote-aliases
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# There are two conventions for remote aliases which require the `oh-my-git`
+# to be parameterised.
+
+
+# FORK_ALIAS should be set to the alias of your fork. This is either
+# `origin` or your <github-username>.
+export FORK_ALIAS=origin
+
+
+# UPSTREAM_ALIAS should be set to the alias of the repository you are
+# sending PR's to. This is usually `upstream` or `origin`.
+export UPSTREAM_ALIAS=upstream


### PR DESCRIPTION
Referring to a repo as `origin` is confusing since some 
conventions clash on its meaning:

 * `upstream` and `origin`
 * `origin` and `<username>`

This PR replaces the use of `origin` with `fork` so it's clearer.